### PR TITLE
ocaml-migrate-parsetree-android.1.0.11 and ppx_tools_versioned-android.5.1

### DIFF
--- a/packages/ocaml-migrate-parsetree-android.1.0.11/descr
+++ b/packages/ocaml-migrate-parsetree-android.1.0.11/descr
@@ -1,0 +1,4 @@
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.

--- a/packages/ocaml-migrate-parsetree-android.1.0.11/opam
+++ b/packages/ocaml-migrate-parsetree-android.1.0.11/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" "ocaml-migrate-parsetree" "-j" jobs]
+]
+depends: [
+  "result-android"
+  "ocamlfind" {build}
+  "jbuilder" {build & >= "1.0+beta18.1"}
+]
+available: ocaml-version >= "4.02.0"

--- a/packages/ocaml-migrate-parsetree-android.1.0.11/url
+++ b/packages/ocaml-migrate-parsetree-android.1.0.11/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.0.11/ocaml-migrate-parsetree-1.0.11.tbz"
+checksum: "26bb1b038de81a79d43ed95c282b2b71"

--- a/packages/ppx_tools_versioned-android.5.1/descr
+++ b/packages/ppx_tools_versioned-android.5.1/descr
@@ -1,0 +1,1 @@
+A variant of ppx_tools based on ocaml-migrate-parsetree

--- a/packages/ppx_tools_versioned-android.5.1/opam
+++ b/packages/ppx_tools_versioned-android.5.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Alain Frisch <alain.frisch@lexifi.com>"
+]
+homepage: "https://github.com/let-def/ppx_tools_versioned"
+bug-reports: "https://github.com/let-def/ppx_tools_versioned/issues"
+license: "MIT"
+tags: "syntax"
+dev-repo: "git://github.com/let-def/ppx_tools_versioned.git"
+build: [make "all"]
+install: ["env" "OCAMLFIND_TOOLCHAIN=android" make "install"]
+remove: ["ocamlfind" "-toolchain" "android" "remove" "ppx_tools_versioned"]
+depends: [
+  "ocamlfind" {>= "1.5.0"}
+  "ocaml-migrate-parsetree" {>= "1.0.7"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ppx_tools_versioned-android.5.1/url
+++ b/packages/ppx_tools_versioned-android.5.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.1.tar.gz"
+checksum: "e48cc87d6da6c2f3020fd8dfe8fe50de"


### PR DESCRIPTION
I added 2 packages.

They are dependencies of other ppx, so they are build for the host and then installed into the android sysroot.

I found the trick in [ppx_deriving-android](https://github.com/ocaml-cross/opam-cross-android/blob/master/packages/ppx_deriving-android.4.1/opam#L14)