### PR TITLE
Don't install graphics

### DIFF
--- a/packages/ocaml-android32.4.04.0/files/install.sh
+++ b/packages/ocaml-android32.4.04.0/files/install.sh
@@ -2,7 +2,7 @@
 
 PREFIX="$1"
 
-for pkg in bigarray bytes compiler-libs dynlink findlib graphics num num-top stdlib str threads unix; do
+for pkg in bigarray bytes compiler-libs dynlink findlib num num-top stdlib str threads unix; do
   cp -r "${PREFIX}/lib/${pkg}" "${PREFIX}/android-sysroot/lib/"
 done
 


### PR DESCRIPTION
Issue https://github.com/ocaml-cross/opam-cross-android/issues/39.

I just removed `graphics` from the list. This may break some packages